### PR TITLE
Adds MacOS/Darwin support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ build/
 # FFmpeg install folder
 ffmpeg/
 
-// Test media files
+# Test media files
 *.MP4
 *.mp4
+
+# Editors and IDE's
+*.swp

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,15 +1,15 @@
 {
   "targets": [{
     "target_name" : "beamcoder",
+    "sources" : [ "src/beamcoder.cc", "src/beamcoder_util.cc",
+                  "src/governor.cc", "src/demux.cc",
+                  "src/decode.cc", "src/filter.cc",
+                  "src/encode.cc", "src/mux.cc",
+                  "src/packet.cc", "src/frame.cc",
+                  "src/codec_par.cc", "src/format.cc",
+                  "src/codec.cc" ],
     "conditions": [
-      ['OS=="linux"', {
-        "sources" : [ "src/beamcoder.cc", "src/beamcoder_util.cc",
-                      "src/governor.cc", "src/demux.cc",
-                      "src/decode.cc", "src/filter.cc",
-                      "src/encode.cc", "src/mux.cc",
-                      "src/packet.cc", "src/frame.cc",
-                      "src/codec_par.cc", "src/format.cc",
-                      "src/codec.cc" ],
+      ['OS!="win"', {
         "defines": [
           "__STDC_CONSTANT_MACROS"
         ],
@@ -35,51 +35,43 @@
         }
       }],
       ['OS=="win"', {
-      "sources" : [ "src/beamcoder.cc", "src/beamcoder_util.cc",
-                    "src/governor.cc", "src/demux.cc",
-                    "src/decode.cc", "src/filter.cc",
-                    "src/encode.cc", "src/mux.cc",
-                    "src/packet.cc", "src/frame.cc",
-                    "src/codec_par.cc", "src/format.cc",
-                    "src/codec.cc" ],
-      "configurations": {
-        "Release": {
-          "msvs_settings": {
-            "VCCLCompilerTool": {
-              "RuntimeTypeInfo": "true"
+        "configurations": {
+          "Release": {
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "RuntimeTypeInfo": "true"
+              }
             }
           }
-        }
-      },
-      "include_dirs" : [
-        "ffmpeg/ffmpeg-4.1-win64-dev/include"
-      ],
-      "libraries": [
-        "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/avcodec",
-        "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/avdevice",
-        "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/avfilter",
-        "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/avformat",
-        "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/avutil",
-        "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/postproc",
-        "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/swresample",
-        "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/swscale"
-      ],
-      "copies": [
-          {
-            "destination": "build/Release/",
-            "files": [
-              "ffmpeg/ffmpeg-4.1-win64-shared/bin/avcodec-58.dll",
-              "ffmpeg/ffmpeg-4.1-win64-shared/bin/avdevice-58.dll",
-              "ffmpeg/ffmpeg-4.1-win64-shared/bin/avfilter-7.dll",
-              "ffmpeg/ffmpeg-4.1-win64-shared/bin/avformat-58.dll",
-              "ffmpeg/ffmpeg-4.1-win64-shared/bin/avutil-56.dll",
-              "ffmpeg/ffmpeg-4.1-win64-shared/bin/postproc-55.dll",
-              "ffmpeg/ffmpeg-4.1-win64-shared/bin/swresample-3.dll",
-              "ffmpeg/ffmpeg-4.1-win64-shared/bin/swscale-5.dll"
-            ]
-          }
-        ]
-
+        },
+        "include_dirs" : [
+          "ffmpeg/ffmpeg-4.1-win64-dev/include"
+        ],
+        "libraries": [
+          "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/avcodec",
+          "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/avdevice",
+          "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/avfilter",
+          "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/avformat",
+          "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/avutil",
+          "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/postproc",
+          "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/swresample",
+          "-l../ffmpeg/ffmpeg-4.1-win64-dev/lib/swscale"
+        ],
+        "copies": [
+            {
+              "destination": "build/Release/",
+              "files": [
+                "ffmpeg/ffmpeg-4.1-win64-shared/bin/avcodec-58.dll",
+                "ffmpeg/ffmpeg-4.1-win64-shared/bin/avdevice-58.dll",
+                "ffmpeg/ffmpeg-4.1-win64-shared/bin/avfilter-7.dll",
+                "ffmpeg/ffmpeg-4.1-win64-shared/bin/avformat-58.dll",
+                "ffmpeg/ffmpeg-4.1-win64-shared/bin/avutil-56.dll",
+                "ffmpeg/ffmpeg-4.1-win64-shared/bin/postproc-55.dll",
+                "ffmpeg/ffmpeg-4.1-win64-shared/bin/swresample-3.dll",
+                "ffmpeg/ffmpeg-4.1-win64-shared/bin/swscale-5.dll"
+              ]
+            }
+          ]
     }]
   ]
 }]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "beamcoder",
-  "version": "0.1.8",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js native bindings to FFmpeg.",
   "main": "index.js",
   "scripts": {
-    "preinstall": "node install_ffmpeg.js",
+    "preinstall": "npm install unzip && node install_ffmpeg.js",
     "install": "node-gyp rebuild",
     "test": "tape test/*.js",
     "lint": "eslint **/*.js",


### PR DESCRIPTION
Installs FFmpeg via Homebrew, and then uses that as the build
dependency. Since Xcode is largely GCC compliant, can re-use the Linux
build instructions.