### PR TITLE
remove koa from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   "homepage": "https://github.com/Streampunk/beamcoder#readme",
   "dependencies": {
     "bindings": "^1.5.0",
-    "koa": "^2.7.0",
-    "segfault-handler": "^1.0.1",
-    "unzip": "^0.1.11"
+    "segfault-handler": "^1.0.1"
   },
   "devDependencies": {
+    "koa": "^2.7.0",
+    "unzip": "^0.1.11",
     "eslint": "^5.15.1",
     "tape": "^4.10.1"
   },

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   "homepage": "https://github.com/Streampunk/beamcoder#readme",
   "dependencies": {
     "bindings": "^1.5.0",
+    "unzip": "^0.1.11",
     "segfault-handler": "^1.0.1"
   },
   "devDependencies": {
     "koa": "^2.7.0",
-    "unzip": "^0.1.11",
     "eslint": "^5.15.1",
     "tape": "^4.10.1"
   },


### PR DESCRIPTION
It is not a dependency of the library itself. From what I can see, koa is only a dependency of some of the examples.

Also, unzip is not a runtime dependency of the library either, as far as I can tell, but only of the install process of the library *on windows*. It should be removed. However, I don't think you can just remove it without rewriting more of the code than I'm willing to just now.