### PR TITLE
only install unzipper on windows

### DIFF
--- a/install_ffmpeg.js
+++ b/install_ffmpeg.js
@@ -23,7 +23,6 @@ const os = require('os');
 const fs = require('fs');
 const util = require('util');
 const https = require('https');
-const unzip = require('unzipper');
 const cp = require('child_process');
 const [ mkdir, access, rename, execFile, exec ] = // eslint-disable-line
   [ fs.mkdir, fs.access, fs.rename, cp.execFile, cp.exec ].map(util.promisify);
@@ -51,6 +50,8 @@ async function get(ws, url, name) {
 }
 
 async function inflate(rs, folder, name) {
+  const unzip = require('unzipper');
+
   return new Promise((comp, err) => {
     console.log(`Unzipping '${folder}/${name}'.`);
     rs.pipe(unzip.Extract({ path: folder }));
@@ -64,6 +65,7 @@ async function inflate(rs, folder, name) {
 
 async function win32() {
   console.log('Installing FFmpeg dependencies for Beam Coder on Windows.');
+  await exec('npm install unzipper');
 
   await mkdir('ffmpeg').catch(e => {
     if (e.code === 'EEXIST') return;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js native bindings to FFmpeg.",
   "main": "index.js",
   "scripts": {
-    "preinstall": "npm install unzipper && node install_ffmpeg.js",
+    "preinstall": "node install_ffmpeg.js",
     "install": "node-gyp rebuild",
     "test": "tape test/*.js",
     "lint": "eslint **/*.js",
@@ -35,8 +35,7 @@
   "dependencies": {
     "bindings": "^1.5.0",
     "koa": "^2.7.0",
-    "segfault-handler": "^1.2.0",
-    "unzipper": "^0.10.0"
+    "segfault-handler": "^1.2.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",


### PR DESCRIPTION
currently, we install unzipper unconditionally, even though it's only required by the window, which causes a lot of unnecessary installs to `node_modules/beamcoder/node_modules`. Additionally, we also depend on it, which causes those same dependencies to also be added to my project, but i think not actually made available to the beamcoder install process if it needs them. This leads to a significant increase in disk usage by programs using beamcoder.

To fix this, we only actually install unzipper inside the windows installer, and only load it near the call site.

FWIW, a better direction for the future might be to factor `install_ffmpeg.js` out into a separate package. You could make it a peer dependency, or just catch ffmpeg-not-found type errors and print "try installing `beamcoder-install-ffmpeg`".