### PR TITLE
Add include dirs on linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -17,6 +17,10 @@
           "-fno-rtti",
           "-fno-exceptions"
         ],
+        "include_dirs" : [
+          "/usr/include/ffmpeg",
+          "/usr/local/include"
+        ],        
         "cflags_cc": [
           "-std=c++11",
           "-fexceptions"


### PR DESCRIPTION
Fixes source header files not found on linux

>In file included from ../src/beamcoder.cc:23:
../src/beamcoder_util.h:33:12: fatal error: libavutil/error.h: No such file or directory