### PR TITLE
Remove await from a function that does not return Promise

### DIFF
--- a/examples/encode_h264.js
+++ b/examples/encode_h264.js
@@ -46,7 +46,7 @@ async function run() {
     priv_data: { preset: 'slow' }
   };
 
-  let encoder = await beamcoder.encoder(encParams);
+  let encoder = beamcoder.encoder(encParams);
   console.log('Encoder', encoder);
 
   let outFile = fs.createWriteStream(process.argv[2]);


### PR DESCRIPTION
The beamcoder.encoder() does not return Promise. However, the example uses await.