### PR TITLE
pass hw_frames_ctx from frame to encoder

### DIFF
--- a/src/beamcoder.cc
+++ b/src/beamcoder.cc
@@ -926,6 +926,9 @@ napi_value Init(napi_env env, napi_value exports) {
     codec = av_codec_iterate(&opaque);
     // printf("Registered '%s'\n", (codec != nullptr) ? codec->name : "(null)");
   } while (codec != nullptr);
+
+  avdevice_register_all();
+
   return exports;
 }
 

--- a/src/encode.cc
+++ b/src/encode.cc
@@ -180,6 +180,10 @@ void encodeExecute(napi_env env, void* data) {
        c->errorMsg = "The encoder has been flushed, and no new frames can be sent to it.";
        return;
      case AVERROR(EINVAL):
+       // if hw context is present in frame, use it
+       if(c->encoder->hw_frames_ctx == nullptr && (*it)->hw_frames_ctx != nullptr) {
+          c->encoder->hw_frames_ctx = av_buffer_ref((*it)->hw_frames_ctx);
+       }
        if ((ret = avcodec_open2(c->encoder, c->encoder->codec, nullptr))) {
          c->status = BEAMCODER_ERROR_ALLOC_ENCODER;
          c->errorMsg = avErrorMsg("Problem opening encoder: ", ret);


### PR DESCRIPTION
1. The idea behind this change is to allow encoder to use hardware accelerated frames. For ex. a frame can be hwuploaded to cuda and filtered with a scale_npp filter. If the hw_frames context is not passed to the encoder, it currently fails in such scenario.

2. The avdevices are currently not initialized on beamcoder init. That's why it's impossible to use a v4l2 device as a demuxer input:

 let dm = await beamcoder.demuxer({
     url: '/dev/video10',
     iformat: "video4linux2",

This will fail with "invalid input" error. Registering the avdevices on init fixes this issue.

