### PR TITLE
Add demuxer.interrupt()

### DIFF
--- a/src/demux.h
+++ b/src/demux.h
@@ -53,6 +53,8 @@ void demuxerFinalizer(napi_env env, void* data, void* hint);
 void readBufferFinalizer(napi_env env, void* data, void* hint);
 
 napi_value forceCloseInput(napi_env env, napi_callback_info info);
+napi_value interrupt(napi_env env, napi_callback_info info);
+int interrupt_callback(void *opaque);
 
 struct demuxerCarrier : carrier {
   const char* filename = nullptr;

--- a/types/Demuxer.d.ts
+++ b/types/Demuxer.d.ts
@@ -76,6 +76,11 @@ export interface Demuxer extends Omit<FormatContext,
 	 * Abandon the demuxing process and forcibly close the file or stream without waiting for it to finish
 	 */
 	forceClose(): undefined
+
+	/**
+	  * This causes any currently blocking IO to be interrupted and raise an "Immediate exit requested" error.
+	  */
+	interrupt(): undefined;
 }
 
 /**


### PR DESCRIPTION
This PR adds an `interrupt()` function to the demuxer instance. Calling interrupt will cause any blocking IO on the demuxer to abort with the AVERROR_EXIT error code.

This is accomplished using the AVIOInterruptCB structure in ffmpeg https://github.com/FFmpeg/FFmpeg/blob/6087692a60699a5eac5b061dd458e5a856e0662f/libavformat/avio.h#L47-L61

I considered adding some special error handling for AVERROR_EXIT, but I wanted to get your feedback first. It might be useful for client applications to be able to differentiate between intentional early exit errors and regular errors. In my app, I'm doing a string match for "Immediate exit requested" on error.message. It's not ideal, but good enough for now.

This resolves my issue https://github.com/Streampunk/beamcoder/issues/54 and I think could also help with https://github.com/Streampunk/beamcoder/issues/53 