### PR TITLE
Fix forceClose() function signature

### DIFF
--- a/types/Demuxer.d.ts
+++ b/types/Demuxer.d.ts
@@ -75,7 +75,7 @@ export interface Demuxer extends Omit<FormatContext,
 	/**
 	 * Abandon the demuxing process and forcibly close the file or stream without waiting for it to finish
 	 */
-	forceClose(): undefined
+	forceClose(): number
 }
 
 /**

--- a/types/Muxer.d.ts
+++ b/types/Muxer.d.ts
@@ -93,7 +93,7 @@ export interface Muxer extends Omit<FormatContext,
 	/**
 	 * Abandon the muxing process and forcibly close the file or stream without completing it
 	 */
-	forceClose(): undefined
+	forceClose(): number
 }
 
 /**


### PR DESCRIPTION
Use ```undefined``` as the return type of the function will trigger eslint rule ```@typescript-eslint/no-unsafe-call``` when call the function. 
I do a quick check of the C code and seem that this function return an int status code, so I change the return type to ```number```.