### PR TITLE
fix: building for macos on m1

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -72,7 +72,15 @@
               ]
             }
           ]
-    }]
+    }],
+    ['OS=="mac"', {
+      "include_dirs" : [
+        "/opt/homebrew/Cellar/ffmpeg/5.0/include"
+      ],
+      "library_dirs": [
+        "/opt/homebrew/Cellar/ffmpeg/5.0/lib",
+      ]
+    }],
   ]
 }]
 }

--- a/install_ffmpeg.js
+++ b/install_ffmpeg.js
@@ -226,7 +226,7 @@ case 'linux':
   }
   break;
 case 'darwin':
-  if (os.arch() != 'x64') {
+  if (os.arch() != 'x64' && os.arch() != 'arm64') {
     console.error('Only 64-bit platforms are supported.');
     process.exit(1);
   } else {


### PR DESCRIPTION
This PR adds the arm64 arch to the install_ffmpeg.js file as well as some instructions as to where to find the homebrew installed ffmpeg in the binding.gyp file.

As a side note: on M1 systems homebrew will install the arm64 version of ffmpeg therefore it is required to also use an arm64 version of nodejs. NodeJS 16 and later will install as arm64 by default.