### PR TITLE
Resolve memory leaks

### DIFF
--- a/src/decode.cc
+++ b/src/decode.cc
@@ -283,8 +283,10 @@ void decodeExecute(napi_env env, void* data) {
         }
         c->frames.push_back(sw_frame);
         av_frame_free(&frame);
-      } else
+      } else {
         c->frames.push_back(frame);
+        av_frame_free(&sw_frame);
+      }
 
       frame = av_frame_alloc();
       sw_frame = av_frame_alloc();

--- a/src/encode.cc
+++ b/src/encode.cc
@@ -206,12 +206,11 @@ void encodeExecute(napi_env env, void* data) {
     ret = avcodec_receive_packet(c->encoder, packet);
     if (ret == 0) {
       c->packets.push_back(packet);
-      packet = av_packet_alloc();
     } else {
+      av_packet_free(&packet);
       //printf("Receive packet got status %i\n", ret);
     }
   } while (ret == 0);
-  av_packet_free(&packet);
 
   c->totalTime = microTime(encodeStart);
   /* if (!c->frames.empty()) {

--- a/src/filter.cc
+++ b/src/filter.cc
@@ -1553,14 +1553,18 @@ void filterExecute(napi_env env, void* data) {
       AVFrame *filtFrame = av_frame_alloc();
       AVFilterContext *sinkCtx = c->sinkCtxs->getContext(*it);
       if (!sinkCtx) {
+        av_frame_free(&filtFrame);
         c->status = BEAMCODER_INVALID_ARGS;
         c->errorMsg = "Sink name not found in sink contexts.";
         return;
       }
       ret = av_buffersink_get_frame(sinkCtx, filtFrame);
-      if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
+      if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+        av_frame_free(&filtFrame);
         break;
+      }
       if (ret < 0) {
+        av_frame_free(&filtFrame);
         c->status = BEAMCODER_ERROR_FILTER_GET_FRAME;
         c->errorMsg = "Error while filtering.";
         return;

--- a/src/format.cc
+++ b/src/format.cc
@@ -3866,8 +3866,7 @@ void formatContextFinalizer(napi_env env, void* data, void* hint) {
       } */
     }
 
-    if (adaptor != nullptr) // crashes otherwise...
-      avformat_free_context(fc);
+    avformat_free_context(fc);
   }
 
   delete fmtRef;


### PR DESCRIPTION
# Description

In production, we noticed a steady increase in memory usage until our nodes would crash due to out of memory. Using valgrind and the pastebin below via `valgrind --leak-check=full node --expose-gc beamcoder.js`, we discovered what appears to be memory leaks in the decoder, encoder, and filters due to frames and packets not being freed. This PR adds the necessary `av_frame_free` and `av_packet_free` calls to avoid this memory leak. Apologies if the code is not ideal. I don't work in C++ day to day

https://pastebin.com/Q2fCP4qa